### PR TITLE
Added before today and already selected date picker boundaries

### DIFF
--- a/src/frontend/src/Components/NewEvent/NewEvent.js
+++ b/src/frontend/src/Components/NewEvent/NewEvent.js
@@ -108,6 +108,10 @@ function NewEvent() {
               <DatePicker
                 selected={startDate}
                 onChange={(date) => setStartDate(date)}
+                minDate={new Date()}
+                excludeDates={propositions.map(
+                  (proposition) => proposition.datetime
+                )}
               />
               <div className="time-slot-btn-container">
                 <button className="cancel-time-slot" onClick={closeTimeSlot}>


### PR DESCRIPTION
Closes #3 

Prop additions to DatePicker to prevent previous dates and already selected dates from being selected.